### PR TITLE
Add variables.tf and outputs.tf to follow Terraform best practices

### DIFF
--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,10 @@
+# outputs.tf
+# Define outputs for Terraform modules
+
+# Example output
+output "resource_group_name" {
+  description = "The name of the resource group."
+  value       = azurerm_resource_group.rg.name
+}
+
+# Add more outputs as needed for your infrastructure

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,11 @@
+# variables.tf
+# Define input variables for Terraform modules
+
+# Example variable
+variable "location" {
+  description = "The Azure region to deploy resources in."
+  type        = string
+  default     = "East US"
+}
+
+# Add more variables as needed for your infrastructure


### PR DESCRIPTION
This PR adds `variables.tf` and `outputs.tf` to the Terraform configuration, following best practices and resolving issue #2.

- `variables.tf` defines input variables (example: location)
- `outputs.tf` defines outputs (example: resource group name)

Please review and merge to improve Terraform maintainability.