### PR TITLE
Add backup configuration for Terraform and Ansible

### DIFF
--- a/ansible/roles/backup/tasks/main.yml
+++ b/ansible/roles/backup/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+- name: Configure backups
+  hosts: all
+  become: yes
+  tasks:
+    - name: Install backup agent
+      package:
+        name: azure-backup-agent
+        state: present
+      when: ansible_os_family == "RedHat" or ansible_os_family == "Debian"
+
+    - name: Configure backup agent
+      template:
+        src: backup-config.j2
+        dest: /etc/azure-backup/config.ini
+        mode: '0644'
+      notify: Restart backup service
+
+  handlers:
+    - name: Restart backup service
+      service:
+        name: azure-backup
+        state: restarted

--- a/terraform/backup.tf
+++ b/terraform/backup.tf
@@ -1,0 +1,45 @@
+# Azure Backup Configuration
+
+resource "azurerm_recovery_services_vault" "vault" {
+  name                = "gemini-backup-vault"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  sku                = "Standard"
+  soft_delete_enabled = true
+}
+
+# Example backup policy for VMs
+resource "azurerm_backup_policy_vm" "daily" {
+  name                = "daily-vm-backup"
+  resource_group_name = azurerm_resource_group.rg.name
+  recovery_vault_name = azurerm_recovery_services_vault.vault.name
+
+  timezone = "UTC"
+
+  backup {
+    frequency = "Daily"
+    time      = "23:00"
+  }
+
+  retention_daily {
+    count = 30
+  }
+
+  retention_weekly {
+    count    = 4
+    weekdays = ["Sunday"]
+  }
+
+  retention_monthly {
+    count    = 12
+    weekdays = ["Sunday"]
+    weeks    = ["First"]
+  }
+
+  retention_yearly {
+    count    = 1
+    weekdays = ["Sunday"]
+    weeks    = ["First"]
+    months   = ["January"]
+  }
+}


### PR DESCRIPTION
This PR adds backup configuration to both Terraform and Ansible:

Terraform:
- Adds Azure Recovery Services Vault
- Configures daily VM backup policy with retention rules

Ansible:
- Adds backup role with agent installation
- Configures backup service and settings

Closes #4