### PR TITLE
Update: GitHub Actions workflow to run only on master branch

### DIFF
--- a/.github/workflows/basic-ci.yml
+++ b/.github/workflows/basic-ci.yml
@@ -3,10 +3,10 @@ name: Basic CI
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     branches:
-      - main
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
This pull request updates the basic GitHub Actions workflow so that CI runs only on the master branch for both push and pull request events.\n\n**Key changes:**\n- The workflow trigger branches are now set to 'master' instead of 'main'.\n- No other logic or steps were changed.\n\nThis ensures that CI/CD is aligned with the repository's default branch naming.\n\n---\n\n**Context:**\n- The .gitignore file remains unchanged and continues to protect infrastructure, compliance, and secret files as before.\n- This update is focused solely on the workflow trigger configuration.